### PR TITLE
Add chat and user tools

### DIFF
--- a/src/app/ai/mcp-server/mcp-server.ts
+++ b/src/app/ai/mcp-server/mcp-server.ts
@@ -94,7 +94,8 @@ export class MCPServer implements ILocalMCPServerInterface {
     }
 
     try {
-      const result = await handler(parameters);
+      // result must be a string (because when chaining tool calls, tool result is injected in the message list and all messages are strings)
+      const result = await handler(parameters).then(JSON.stringify);
 
       return {
         type: 'function_call_response',

--- a/src/app/ai/mcp-server/tools/c2Registry/chat-creation.ts
+++ b/src/app/ai/mcp-server/tools/c2Registry/chat-creation.ts
@@ -1,0 +1,62 @@
+import { IMCPTool, IRegistryServiceTools } from '../../../mcp-models';
+
+const symbol = 'IChatCreationService';
+
+const createRoomParams = {
+  type: 'object',
+  properties: {
+    users: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+          },
+        },
+        required: ['id'],
+      },
+      description:
+        'The users to create the chat room with (default value: empty array)',
+    },
+    roomName: {
+      type: 'string',
+      description:
+        'The name of the chat room to create (default value: empty string)',
+    },
+    roomSettings: {
+      type: 'object',
+      description: `The settings of the chat room to create (default value: empty object). Here is the list of available settings:
+        - public (true/false)
+        - external (true/false)
+        - multilateral (true/false - only for external chats)
+        - allowHistoryBrowsing (true/false)
+        - allowMessageCopy (true/false)
+        - allowSendMessages (true/false)
+        - allowAddUser (true/false)
+        - allowReactions (true/false)
+        - discoverable (true/false)
+        - message (string)`,
+    },
+  },
+  required: ['users', 'roomName', 'roomSettings'],
+};
+
+const tools: IMCPTool[] = [
+  // Uncomment to create rooms with no user confirmation - (╯°□°)╯︵ ʎʇǝɟɐs
+  // {
+  //   name: 'createChatRoom',
+  //   description: `Creates the chat room with the provided users and room name, and using the provided settings. Requires confirmation prompt.`,
+  //   parameters: createRoomParams,
+  // },
+  {
+    name: 'displayCreateChatRoomPanel',
+    description: `Displays the chat room creation panel pre-filled with the provided users and room name, and using the provided settings. Users can only be specified by their id attribute which can .`,
+    parameters: createRoomParams,
+  },
+];
+
+export const registryTools: IRegistryServiceTools = {
+  symbol,
+  tools,
+};

--- a/src/app/ai/mcp-server/tools/c2Registry/chat.ts
+++ b/src/app/ai/mcp-server/tools/c2Registry/chat.ts
@@ -1,0 +1,40 @@
+import { IMCPTool, IRegistryServiceTools } from '../../../mcp-models';
+
+const symbol = 'IChatService';
+
+const tools: IMCPTool[] = [
+  {
+    name: 'openChat',
+    description: `Opens the chat having the given id.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'The id of the chat to open.',
+        },
+        name: {
+          type: 'string',
+          description:
+            'The name of the module to open (value is always undefined).',
+        },
+        itemType: {
+          type: 'string',
+          description: 'The type of the module to open (value is always 0).',
+        },
+        chatOptions: {
+          type: 'object',
+          description: `The open chat options (default value: undefined). Here is the list of available options:
+          - openMode (0 to open as a pinned module, 2 to open in a new tab, 3 to open a pinned tab, 4 to open next to the currently opened chats, 6 to open in a popout window)
+          `,
+        },
+      },
+      required: ['id', 'name', 'itemType', 'chatOptions'],
+    },
+  },
+];
+
+export const registryTools: IRegistryServiceTools = {
+  symbol,
+  tools,
+};

--- a/src/app/ai/mcp-server/tools/c2Registry/index.ts
+++ b/src/app/ai/mcp-server/tools/c2Registry/index.ts
@@ -1,2 +1,6 @@
 export { registryTools as confirmationPromptTools } from './confirmation-prompt';
 export { registryTools as extensionAppActionsTools } from './extension-app-actions';
+export { registryTools as chatCreationTools } from './chat-creation';
+export { registryTools as userStoreTools } from './user-store';
+export { registryTools as streamStoreTools } from './stream-store';
+export { registryTools as chatTools } from './chat';

--- a/src/app/ai/mcp-server/tools/c2Registry/stream-store.ts
+++ b/src/app/ai/mcp-server/tools/c2Registry/stream-store.ts
@@ -1,0 +1,31 @@
+import { IMCPTool, IRegistryServiceTools } from '../../../mcp-models';
+
+const symbol = 'IStreamStore';
+
+const tools: IMCPTool[] = [
+  {
+    name: 'searchRooms',
+    description: `Returns the chats matching the given terms.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        roomQuery: {
+          type: 'object',
+          description:
+            'The room query object containing a string query property which corresponds to the search terms (result contains all the information of the chats matching the query, including the chat id).',
+        },
+        maxResults: {
+          type: 'number',
+          description:
+            'The maximum number of retrieved chats matching the query (value is always 20).',
+        },
+      },
+      required: ['roomQuery', 'maxResults'],
+    },
+  },
+];
+
+export const registryTools: IRegistryServiceTools = {
+  symbol,
+  tools,
+};

--- a/src/app/ai/mcp-server/tools/c2Registry/user-store.ts
+++ b/src/app/ai/mcp-server/tools/c2Registry/user-store.ts
@@ -1,0 +1,48 @@
+import { IMCPTool, IRegistryServiceTools } from '../../../mcp-models';
+
+const symbol = 'IUserStore';
+
+const tools: IMCPTool[] = [
+  {
+    name: 'getMyInfo',
+    description: `Returns the information relative to the current user (me).`,
+    parameters: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'findUserByEmail',
+    description: `Returns the user matching the given email address (result contains all the information of the user matching the provided email, including the user id).`,
+    parameters: {
+      type: 'object',
+      properties: {
+        email: {
+          type: 'string',
+          description: 'The email of the target user to find.',
+        },
+      },
+      required: ['email'],
+    },
+  },
+  {
+    name: 'findUserByName',
+    description: `Returns the users matching the given name (result contains all the information of the users matching the provided name, including the user id and email).`,
+    parameters: {
+      type: 'object',
+      properties: {
+        value: {
+          type: 'string',
+          description: 'The name of the target user to find.',
+        },
+      },
+      required: ['value'],
+    },
+  },
+];
+
+export const registryTools: IRegistryServiceTools = {
+  symbol,
+  tools,
+};

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -605,8 +605,6 @@ ipcMain.handle(
       case apiCmds.getCurrentOriginUrl:
         return windowHandler.getMainWindow()?.origin;
       case apiCmds.askSymAi:
-        // TODO call MCP client
-        logger.info('Yup got here');
         return mcpClient.generateResponse(arg.symAiQuestion);
       case apiCmds.showScreenSharePermissionDialog: {
         const focusedWindow = BrowserWindow.getFocusedWindow();


### PR DESCRIPTION
New tools:
- displayChatCreationPanel
- findUserByName
- findUserByEmail
- getMyInfo
- searchRooms
- openChat

Example of potential supported features:
- "Who am I?"
- "Open the BYC chat next to the other ones"
- "Open the Sophia Antipolis chat in a popout window"
- "Create an external chat with Benoit Carbonito where members can't add new members and where the initial message is a joke about AI"

⚠️  You may need to disable the confirmation prompt tool otherwise you'll get spammed